### PR TITLE
Changed `RetrieveResponseItem.Type` to `string`

### DIFF
--- a/Loqate/Loqate.csproj
+++ b/Loqate/Loqate.csproj
@@ -9,7 +9,7 @@
 	  <Description>Open source HTTPS client for Loqate's services.</Description>
 	  <PackageProjectUrl></PackageProjectUrl>
 	  <RepositoryUrl>https://github.com/rombethor/loqate</RepositoryUrl>
-	  <Version>8.1.0</Version>
+	  <Version>8.2.0</Version>
 	  <Title>Loqate HTTP Client</Title>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Loqate/Retrieve/RetrieveResponseItem.cs
+++ b/Loqate/Retrieve/RetrieveResponseItem.cs
@@ -115,7 +115,7 @@ namespace Loqate.Retrieve
         public string? Label { get; set; }
 
         [JsonPropertyName("Type")]
-        public RecordType Type { get; set; }
+        public string? Type { get; set; }
 
         [JsonPropertyName("DataLevel")]
         public string? DataLevel { get; set; }


### PR DESCRIPTION
Documentation does not provide possible values for `Type` in Retrieve call but they appear to be different from the types provided by the Find endpoint.  Therefore changing the deserialization to `string`.  

When upgrading the package, existing usage of `RetrieveResponseItem.Type` will need updating also.
 
Closes #4 